### PR TITLE
Replace ee with ir studio: Naming, GitHub references, and hyperlinks 

### DIFF
--- a/docs/d__partials/community/channels.md
+++ b/docs/d__partials/community/channels.md
@@ -5,7 +5,7 @@
 - [Discord](https://discord.gg/xrf)
 -->
 
-You can join Ethereal Engine's community on:
+You can join iR Engine's community on:
 - [Twitter](https://twitter.com/xr_engine)
 - [Facebook](https://www.facebook.com/xrengine/)
 - [Discord](https://discord.gg/xrf)

--- a/docs/d__partials/contributing/develop.md
+++ b/docs/d__partials/contributing/develop.md
@@ -1,2 +1,2 @@
-iR Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
-You can find the source code of the engine on iR Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
+iR Engine is an open-source project, based on the [CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) license.
+You can find the source code of the engine on iR Engine's [GitHub](https://github.com/ir-engine/ir-engine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/ir-engine/etherealengine#contributing) section of the repository's readme.

--- a/docs/d__partials/contributing/develop.md
+++ b/docs/d__partials/contributing/develop.md
@@ -1,2 +1,2 @@
-Ethereal Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
-You can find the source code of the engine on Ethereal Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
+iR Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
+You can find the source code of the engine on iR Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.

--- a/docs/d__partials/contributing/documentation.md
+++ b/docs/d__partials/contributing/documentation.md
@@ -1,6 +1,6 @@
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main Ethereal Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
 
 For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 

--- a/docs/d__partials/contributing/documentation.md
+++ b/docs/d__partials/contributing/documentation.md
@@ -1,7 +1,7 @@
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/ir-engine/ir-engine).  
 
-For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
+For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/ir-engine/developer-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 
 Get started by reading the [Get Involved: Documentation Guidelines](/manual/contributing/documentation).

--- a/docs/d__partials/contributing/host.md
+++ b/docs/d__partials/contributing/host.md
@@ -1,5 +1,5 @@
-Ethereal Engine is a platform aimed at helping you achieve your goals.
+iR Engine is a platform aimed at helping you achieve your goals.
 And nothing showcases a great tool better than some great projects made with it!
 
-Complete the **Getting Started** tutorials, learn to use the engine with the [Ethereal Engine Manual](/manual), create a cool project that you love and then share it with the world.
-<!-- TODO: Revise the copywriting of this paragraph after the `Promote Ethereal Engine` copy has been revised, so that it segues better into the next section. -->
+Complete the **Getting Started** tutorials, learn to use the engine with the [iR Engine Manual](/manual), create a cool project that you love and then share it with the world.
+<!-- TODO: Revise the copywriting of this paragraph after the `Promote iR Engine` copy has been revised, so that it segues better into the next section. -->

--- a/docs/d__partials/contributing/participate.md
+++ b/docs/d__partials/contributing/participate.md
@@ -1,3 +1,3 @@
-The easiest way to get involved is to participate in Ethereal Engine's community.  
+The easiest way to get involved is to participate in iR Engine's community.  
 Join us on your favorite [community channel](/manual/community) and become a part of the conversation.  
 Ask any questions that you may have and/or help other users with their questions.

--- a/docs/d__partials/contributing/promote.md
+++ b/docs/d__partials/contributing/promote.md
@@ -1,2 +1,2 @@
-Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of Ethereal Engine is a great way to help growing the community.  
+Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of iR Engine is a great way to help growing the community.  
 <!-- TODO: Improve the copywriting quality of this paragraph with better marketing information, based on Ethereal's marketing strategy. -->

--- a/docs/d__partials/contributing/test.md
+++ b/docs/d__partials/contributing/test.md
@@ -1,4 +1,4 @@
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
 Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
-Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
+Search for the issue in our [Issues List](https://github.com/ir-engine/ir-engine/issues), and open a new one if you think that what you found has not been reported yet.

--- a/docs/d__partials/contributing/test.md
+++ b/docs/d__partials/contributing/test.md
@@ -1,4 +1,4 @@
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
-Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of Ethereal Engine.
+Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
 Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.

--- a/docs/d__partials/defaultProjects.md
+++ b/docs/d__partials/defaultProjects.md
@@ -1,4 +1,4 @@
-Ethereal Engine has a few scenes that are installed by default.  
+iR Engine has a few scenes that are installed by default.  
 With the engine running, open the Studio by navigating to https://localhost:3000/studio, and you will see the engine's default project listed in that page.  
 
 Lets give it a test run:

--- a/docs/d__partials/installUbuntu.md
+++ b/docs/d__partials/installUbuntu.md
@@ -1,5 +1,5 @@
 :::important
-Ethereal Engine is a web application.  
+iR Engine is a web application.  
 We are going to install and run a local version of the engine.  
 But this setup might not reflect how you will use the engine on a day to day basis.  
 :::
@@ -9,11 +9,11 @@ These installation instructions assume you are using Ubuntu Linux.
 You can find alternative _(and more advanced)_ installation instructions for [Windows](/manual/install/windowsWSL), [Mac](/manual/install/macOSX) and [Linux](/manual/install/linux) in the Manual.
 :::
 
-If you are on Ubuntu Linux, there is an automatic installation script to setup and run a local version of Ethereal Engine.  
+If you are on Ubuntu Linux, there is an automatic installation script to setup and run a local version of iR Engine.  
 Open a terminal window and run these two lines:  
 > Make sure that you open the terminal in the folder where you want to install the engine
 ```bash
 wget https://raw.githubusercontent.com/EtherealEngine/etherealengine/dev/scripts/ubuntu-install.sh && bash -i ./ubuntu-install.sh
 npm run reinit && npm run dev
 ```
-You can now open Ethereal Engine on your web browser by navigating to https://localhost:3000
+You can now open iR Engine on your web browser by navigating to https://localhost:3000

--- a/docs/d__partials/installUbuntu.md
+++ b/docs/d__partials/installUbuntu.md
@@ -13,7 +13,7 @@ If you are on Ubuntu Linux, there is an automatic installation script to setup a
 Open a terminal window and run these two lines:  
 > Make sure that you open the terminal in the folder where you want to install the engine
 ```bash
-wget https://raw.githubusercontent.com/EtherealEngine/etherealengine/dev/scripts/ubuntu-install.sh && bash -i ./ubuntu-install.sh
+wget https://raw.githubusercontent.com/ir-engine/ir-engine/dev/scripts/ubuntu-install.sh && bash -i ./ubuntu-install.sh
 npm run reinit && npm run dev
 ```
 You can now open iR Engine on your web browser by navigating to https://localhost:3000

--- a/docs/d__partials/license.md
+++ b/docs/d__partials/license.md
@@ -1,7 +1,7 @@
-iR Engine is [open-source](https://github.com/EtherealEngine/etherealengine), under the terms and conditions of the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.  
-Attribution is required if you wish to use iR Engine under [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE).  
-Please see the attribution guidelines in iR Engine's [LICENSE](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) file.
+iR Engine is [open-source](https://github.com/ir-engine/ir-engine), under the terms and conditions of the [CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) license.  
+Attribution is required if you wish to use iR Engine under [CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE).  
+Please see the attribution guidelines in iR Engine's [LICENSE](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) file.
 
 Other licensing options are available, please contact us for more information.
 
-[CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) - Copyright (c) 2021-2023 iR Engine, formerly known as XREngine by XR Foundation
+[CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) - Copyright (c) 2021-2023 iR Engine, formerly known as XREngine by XR Foundation

--- a/docs/d__partials/license.md
+++ b/docs/d__partials/license.md
@@ -1,7 +1,7 @@
-Ethereal Engine is [open-source](https://github.com/EtherealEngine/etherealengine), under the terms and conditions of the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.  
-Attribution is required if you wish to use Ethereal Engine under [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE).  
-Please see the attribution guidelines in Ethereal Engine's [LICENSE](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) file.
+iR Engine is [open-source](https://github.com/EtherealEngine/etherealengine), under the terms and conditions of the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.  
+Attribution is required if you wish to use iR Engine under [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE).  
+Please see the attribution guidelines in iR Engine's [LICENSE](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) file.
 
 Other licensing options are available, please contact us for more information.
 
-[CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) - Copyright (c) 2021-2023 Ethereal Engine, formerly known as XREngine by XR Foundation
+[CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) - Copyright (c) 2021-2023 iR Engine, formerly known as XREngine by XR Foundation

--- a/docs/d__partials/roadmap/overview.md
+++ b/docs/d__partials/roadmap/overview.md
@@ -1,7 +1,7 @@
 Learning / reading content is much much faster than the amount of the time it takes to write it.  
 
 Due to this website being In-Development, you will eventually find an "end of the road" type of situation.  
-There will be no more content written, but you won't have learned everything there is to know about Ethereal Engine yet.
+There will be no more content written, but you won't have learned everything there is to know about iR Engine yet.
 
 This Roadmap is meant to alleviate that problem as much as possible.  
 Even if you don't have a specific guide teaching you _how_ to do something... you might be able to figure it out on your own if you know exactly **what** you need to research about.  
@@ -10,9 +10,9 @@ Knowing exactly **what you need to know** will get you _(at least)_ 50% of the w
 This Roadmap contains:
 - A list of all concepts required to learn Etheral Engine for the Learning Path you chose
 - A short definition of each concept
-- Links to the Roadmaps of the other Learning Paths, so you can have a clearer mental model of Ethereal Engine as a whole
+- Links to the Roadmaps of the other Learning Paths, so you can have a clearer mental model of iR Engine as a whole
 
 :::note
-The goal of these definitions is (also) to help you differentiate these concepts from other concepts that might be using the same (or very similar) words outside of the context of Ethereal Engine.
+The goal of these definitions is (also) to help you differentiate these concepts from other concepts that might be using the same (or very similar) words outside of the context of iR Engine.
 :::
 

--- a/docs/d__partials/roadmap/tldr.md
+++ b/docs/d__partials/roadmap/tldr.md
@@ -1,4 +1,4 @@
 > *TL;DR:* If you get lost, but you have a roadmap, at least you will know _where_ you need to go.  
 >
-> This Roadmap will help you know exactly **what you need to know** to learn Ethereal Engine.  
+> This Roadmap will help you know exactly **what you need to know** to learn iR Engine.  
 > Armed with this Roadmap, you should be able to do your own research and figure out the Engine on your own.  

--- a/docs/d_creator/02_basics/70_project/d_index.md
+++ b/docs/d_creator/02_basics/70_project/d_index.md
@@ -1,7 +1,7 @@
 # Hero Project
 <!--
 NOTE: This page should contain:
-- Hero Project: Showcase for Ethereal Engine's development tools and workflows
+- Hero Project: Showcase for iR Engine's development tools and workflows
 - Guide: Expands on the Basics tutorial, and teaches the user how to program the Hero Project and be comfortable with EE project development
 - Segue: Lead the user into the Beyond The Basics guide
 

--- a/docs/d_creator/02_basics/d_index.md
+++ b/docs/d_creator/02_basics/d_index.md
@@ -1,12 +1,12 @@
 <!-- import DocCardList from '@theme/DocCardList'; -->
 
-# Ethereal Engine Basics
+# iR Engine Basics
 This guide is a continuation of the [Hello World Tutorial](../gettingStarted/hello).  
 In this guide you will learn how to start expanding your knowledge of the engine beyond the Quickstart introductory guide.  
 <!--
 NOTE: This section should contain:
 - Guide: Teaches a new user how to program the Hero Project and be comfortable with EE project development.
-- Hero Project: Showcase for Ethereal Engine's development tools and workflows.
+- Hero Project: Showcase for iR Engine's development tools and workflows.
 -->
 
 <!-- <DocCardList /> -->

--- a/docs/d_creator/02_basics/index.md
+++ b/docs/d_creator/02_basics/index.md
@@ -1,12 +1,12 @@
 <!-- import DocCardList from '@theme/DocCardList'; -->
 
-# Ethereal Engine Basics
+# iR Engine Basics
 This guide is a continuation of the [Hello World Tutorial](../gettingStarted/hello).  
 In this guide you will learn how to start expanding your knowledge of the engine beyond the Quickstart introductory guide.  
 <!--
 NOTE: This section should contain:
 - Guide: Teaches a new user how to program the Hero Project and be comfortable with EE project development.
-- Hero Project: Showcase for Ethereal Engine's development tools and workflows.
+- Hero Project: Showcase for iR Engine's development tools and workflows.
 -->
 
 <!-- <DocCardList /> -->

--- a/docs/d_creator/96_tutorials/02_unreal_bridge.md
+++ b/docs/d_creator/96_tutorials/02_unreal_bridge.md
@@ -6,15 +6,15 @@ hide_table_of_contents: true
 <iframe width="100%" height="600" src="https://www.youtube.com/embed/GbOpJRxkux8?&theme=dark&rel=0" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen" allowfullscreen></iframe>
 
 
-# Ethereal Engine Bridge - Unreal
+# iR Engine Bridge - Unreal
 
 https://github.com/EtherealEngine/EE-Bridge-Unreal
 
-Unreal SDK Ethereal Engine Alpha
+Unreal SDK iR Engine Alpha
 - User Management API
 - Server Party Matchmaker
 - Unreal Game Server Lifecycle System
-- Unreal Blueprints Ethereal Engine SDK
+- Unreal Blueprints iR Engine SDK
 
 CMS and marketplace services coming soon
 
@@ -55,7 +55,7 @@ TroveServer.exe IslandLobby.uproject /Trove/Maps/Island1?game=MyGameInfo?listen 
 TroveServer.exe IsleOfDeath.uproject /Trove/Maps/IsleOfDeathStart?game=MyGameInfo?listen -stakedgame -server 127.0.0.1
 ```
 
-## VaREST and wrapping the Ethereal Engine Web API 
+## VaREST and wrapping the iR Engine Web API 
 
 knowledge required: Learn REST APIs, OpenAPI, Header based http auth, Verbs:Get/Post/etc, paylods, json
 
@@ -63,17 +63,17 @@ knowledge required: Learn REST APIs, OpenAPI, Header based http auth, Verbs:Get/
 
 Targeting support for 4.26 and 4.27
 
-Trial implementations on epic games unreal examples for the Ethereal Engine bridge for Unreal
+Trial implementations on epic games unreal examples for the iR Engine bridge for Unreal
 
 https://github.com/EtherealEngine/EE-Bridge-Unreal
 
-This bridge is wrapping OpenAPI endpoints presented by Ethereal Engine 
+This bridge is wrapping OpenAPI endpoints presented by iR Engine 
 
 https://api-dev.etherealengine.com/openapi/
 
 This first requires a generated bearer token for API autorization. OAuth API app digestion with socpes is coming soon!
 
-This can be found in the EnvVars of the Ethereal Engine cluster and in the XRE SQL Database
+This can be found in the EnvVars of the iR Engine cluster and in the XRE SQL Database
 
 <img width="1189" alt="Screen Shot 2022-06-04 at 4 25 43 PM" src="https://user-images.githubusercontent.com/5104160/172028647-084f7aa0-d358-4b15-b6be-5788ee7d7ec4.png" />
 
@@ -83,7 +83,7 @@ https://docs.unrealengine.com/4.27/en-US/InteractiveExperiences/Networking/Bluep
 
 All K8 control plane systems can be access via rest calls to the local network of the gameserver, the functionality of Agones can be done via adding a node in Blueprints.
 
-The Ethereal Engine matchmaker service exposes the default endopints for open match.
+The iR Engine matchmaker service exposes the default endopints for open match.
 
 https://github.com/EtherealEngine/ethereal-engine-ops/tree/master/open-match/templates/01-open-match-core.yaml
 https://github.com/EtherealEngine/ethereal-engine-ops/tree/master/open-match/templates/07-open-match-default-evaluator.yaml
@@ -92,7 +92,7 @@ REST API local call access docs
 
 https://open-match.dev/site/docs/guides/access/
 
-This is a ticketing system to be placed into a lobby group and then into a gameserver. Ethereal Engine has API call examples of this
+This is a ticketing system to be placed into a lobby group and then into a gameserver. iR Engine has API call examples of this
 
 Match User Relation
 
@@ -139,17 +139,17 @@ Add Plugins
 
 Targeting support for 4.26 and 4.27
 
-Trial implementations on epic games unreal examples for the Ethereal Engine bridge for Unreal
+Trial implementations on epic games unreal examples for the iR Engine bridge for Unreal
 
 https://github.com/EtherealEngine/EE-Bridge-Unreal
 
-This bridge is wrapping OpenAPI endpoints presented by Ethereal Engine 
+This bridge is wrapping OpenAPI endpoints presented by iR Engine 
 
 https://api-dev.etherealengine.com/openapi/
 
 This first requires a generated bearer token for API autorization. OAuth API app digestion with socpes is coming soon!
 
-This can be found in the EnvVars of the Ethereal Engine cluster and in the XRE SQL Database
+This can be found in the EnvVars of the iR Engine cluster and in the XRE SQL Database
 
 <img width="1189" alt="Screen Shot 2022-06-04 at 4 25 43 PM" src="https://user-images.githubusercontent.com/5104160/172028647-084f7aa0-d358-4b15-b6be-5788ee7d7ec4.png" />
 

--- a/docs/d_creator/96_tutorials/02_unreal_bridge.md
+++ b/docs/d_creator/96_tutorials/02_unreal_bridge.md
@@ -8,7 +8,7 @@ hide_table_of_contents: true
 
 # iR Engine Bridge - Unreal
 
-https://github.com/EtherealEngine/EE-Bridge-Unreal
+https://github.com/ir-engine/EE-Bridge-Unreal
 
 Unreal SDK iR Engine Alpha
 - User Management API
@@ -18,7 +18,7 @@ Unreal SDK iR Engine Alpha
 
 CMS and marketplace services coming soon
 
-EXAMPLE https://github.com/EtherealEngine/EE-Bridge-Unreal-Example
+EXAMPLE https://github.com/ir-engine/EE-Bridge-Unreal-Example
 
 ![Screenshot 2022-06-06 193750](https://user-images.githubusercontent.com/5104160/172299848-3e1c6a5f-ecd2-4562-a894-0d8b55e5b9e5.png)
 
@@ -65,7 +65,7 @@ Targeting support for 4.26 and 4.27
 
 Trial implementations on epic games unreal examples for the iR Engine bridge for Unreal
 
-https://github.com/EtherealEngine/EE-Bridge-Unreal
+https://github.com/ir-engine/EE-Bridge-Unreal
 
 This bridge is wrapping OpenAPI endpoints presented by iR Engine 
 
@@ -85,8 +85,8 @@ All K8 control plane systems can be access via rest calls to the local network o
 
 The iR Engine matchmaker service exposes the default endopints for open match.
 
-https://github.com/EtherealEngine/ethereal-engine-ops/tree/master/open-match/templates/01-open-match-core.yaml
-https://github.com/EtherealEngine/ethereal-engine-ops/tree/master/open-match/templates/07-open-match-default-evaluator.yaml
+https://github.com/ir-engine/ir-engine-ops/tree/master/open-match/templates/01-open-match-core.yaml
+https://github.com/ir-engine/ir-engine-ops/tree/master/open-match/templates/07-open-match-default-evaluator.yaml
 
 REST API local call access docs
 
@@ -123,7 +123,7 @@ Agones Actions
 
 # Ethereal-Engine-Bridge-Unreal-Example
 
-https://github.com/EtherealEngine/EE-Bridge-Unreal-Example
+https://github.com/ir-engine/EE-Bridge-Unreal-Example
 
 Preinstall Requirements
 
@@ -141,7 +141,7 @@ Targeting support for 4.26 and 4.27
 
 Trial implementations on epic games unreal examples for the iR Engine bridge for Unreal
 
-https://github.com/EtherealEngine/EE-Bridge-Unreal
+https://github.com/ir-engine/EE-Bridge-Unreal
 
 This bridge is wrapping OpenAPI endpoints presented by iR Engine 
 

--- a/docs/d_creator/98_contribute/index.md
+++ b/docs/d_creator/98_contribute/index.md
@@ -45,7 +45,7 @@ Talk about the engine with people you know. Let them know about those cool proje
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
 Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
-Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
+Search for the issue in our [Issues List](https://github.com/ir-engine/ir-engine/issues), and open a new one if you think that what you found has not been reported yet.
 
 <!-- End of partial: Test -->
 
@@ -53,9 +53,9 @@ Search for the issue in our [Issues List](https://github.com/EtherealEngine/ethe
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/ir-engine/ir-engine).  
 
-For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
+For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/ir-engine/developer-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 
 Get started by reading the [Get Involved: Documentation Guidelines](/manual/contributing/documentation).
 

--- a/docs/d_creator/98_contribute/index.md
+++ b/docs/d_creator/98_contribute/index.md
@@ -17,7 +17,7 @@ TODO
 
 ## Participate in the community
 <!-- Start of partial: Participate -->
-The easiest way to get involved is to participate in Ethereal Engine's community.  
+The easiest way to get involved is to participate in iR Engine's community.  
 Join us on your favorite [community channel](/manual/community) and become a part of the conversation.  
 Ask any questions that you may have and/or help other users with their questions.
 
@@ -25,17 +25,17 @@ Ask any questions that you may have and/or help other users with their questions
 
 ## Create and Host your own worlds
 <!-- Start of partial: Host -->
-Ethereal Engine is a platform aimed at helping you achieve your goals.
+iR Engine is a platform aimed at helping you achieve your goals.
 And nothing showcases a great tool better than some great projects made with it!
 
-Complete the **Getting Started** tutorials, learn to use the engine with the [Ethereal Engine Manual](/manual), create a cool project that you love and then share it with the world.
-<!-- TODO: Revise the copywriting of this paragraph after the `Promote Ethereal Engine` copy has been revised, so that it segues better into the next section. -->
+Complete the **Getting Started** tutorials, learn to use the engine with the [iR Engine Manual](/manual), create a cool project that you love and then share it with the world.
+<!-- TODO: Revise the copywriting of this paragraph after the `Promote iR Engine` copy has been revised, so that it segues better into the next section. -->
 
 <!-- End of partial: Host -->
 
-## Promote Ethereal Engine
+## Promote iR Engine
 <!-- Start of partial: Promote -->
-Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of Ethereal Engine is a great way to help growing the community.  
+Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of iR Engine is a great way to help growing the community.  
 <!-- TODO: Improve the copywriting quality of this paragraph with better marketing information, based on Ethereal's marketing strategy. -->
 
 <!-- End of partial: Promote -->
@@ -43,17 +43,17 @@ Talk about the engine with people you know. Let them know about those cool proje
 ## Testing and reporting issues
 <!-- Start of partial: Test -->
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
-Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of Ethereal Engine.
+Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
 Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
 
 <!-- End of partial: Test -->
 
-## Contribute to Ethereal Engine's documentation
+## Contribute to iR Engine's documentation
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main Ethereal Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
 
 For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 
@@ -61,7 +61,7 @@ Get started by reading the [Get Involved: Documentation Guidelines](/manual/cont
 
 <!-- End of partial: Documentation -->
 
-## Translate Ethereal Engine
+## Translate iR Engine
 <!-- Start of partial: Translate -->
 <!--
 TODO
@@ -71,5 +71,5 @@ TODO
 
 <!--
 TODO
-## Donate to Ethereal Engine
+## Donate to iR Engine
 -->

--- a/docs/d_creator/99_community/index.md
+++ b/docs/d_creator/99_community/index.md
@@ -30,7 +30,7 @@ TODO
 - [Discord](https://discord.gg/xrf)
 -->
 
-You can join Ethereal Engine's community on:
+You can join iR Engine's community on:
 - [Twitter](https://twitter.com/xr_engine)
 - [Facebook](https://www.facebook.com/xrengine/)
 - [Discord](https://discord.gg/xrf)

--- a/docs/developer/d_visualscript/98_contributing/index.md
+++ b/docs/developer/d_visualscript/98_contributing/index.md
@@ -45,7 +45,7 @@ Talk about the engine with people you know. Let them know about those cool proje
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
 Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
-Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
+Search for the issue in our [Issues List](https://github.com/ir-engine/ir-engine/issues), and open a new one if you think that what you found has not been reported yet.
 
 <!-- End of partial: Test -->
 
@@ -53,9 +53,9 @@ Search for the issue in our [Issues List](https://github.com/EtherealEngine/ethe
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/ir-engine/ir-engine).  
 
-For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
+For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/ir-engine/developer-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 
 Get started by reading the [Get Involved: Documentation Guidelines](/manual/contributing/documentation).
 

--- a/docs/developer/d_visualscript/98_contributing/index.md
+++ b/docs/developer/d_visualscript/98_contributing/index.md
@@ -17,7 +17,7 @@ TODO
 
 ## Participate in the community
 <!-- Start of partial: Participate -->
-The easiest way to get involved is to participate in Ethereal Engine's community.  
+The easiest way to get involved is to participate in iR Engine's community.  
 Join us on your favorite [community channel](/manual/community) and become a part of the conversation.  
 Ask any questions that you may have and/or help other users with their questions.
 
@@ -25,17 +25,17 @@ Ask any questions that you may have and/or help other users with their questions
 
 ## Create and Host your own worlds
 <!-- Start of partial: Host -->
-Ethereal Engine is a platform aimed at helping you achieve your goals.
+iR Engine is a platform aimed at helping you achieve your goals.
 And nothing showcases a great tool better than some great projects made with it!
 
-Complete the **Getting Started** tutorials, learn to use the engine with the [Ethereal Engine Manual](/manual), create a cool project that you love and then share it with the world.
-<!-- TODO: Revise the copywriting of this paragraph after the `Promote Ethereal Engine` copy has been revised, so that it segues better into the next section. -->
+Complete the **Getting Started** tutorials, learn to use the engine with the [iR Engine Manual](/manual), create a cool project that you love and then share it with the world.
+<!-- TODO: Revise the copywriting of this paragraph after the `Promote iR Engine` copy has been revised, so that it segues better into the next section. -->
 
 <!-- End of partial: Host -->
 
 ## Promote iR Engine
 <!-- Start of partial: Promote -->
-Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of Ethereal Engine is a great way to help growing the community.  
+Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of iR Engine is a great way to help growing the community.  
 <!-- TODO: Improve the copywriting quality of this paragraph with better marketing information, based on Ethereal's marketing strategy. -->
 
 <!-- End of partial: Promote -->
@@ -43,7 +43,7 @@ Talk about the engine with people you know. Let them know about those cool proje
 ## Testing and reporting issues
 <!-- Start of partial: Test -->
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
-Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of Ethereal Engine.
+Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
 Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
 
@@ -53,7 +53,7 @@ Search for the issue in our [Issues List](https://github.com/EtherealEngine/ethe
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main Ethereal Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
 
 For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 

--- a/docs/developer/d_visualscript/99_community/index.md
+++ b/docs/developer/d_visualscript/99_community/index.md
@@ -30,7 +30,7 @@ TODO
 - [Discord](https://discord.gg/xrf)
 -->
 
-You can join Ethereal Engine's community on:
+You can join iR Engine's community on:
 - [Twitter](https://twitter.com/xr_engine)
 - [Facebook](https://www.facebook.com/xrengine/)
 - [Discord](https://discord.gg/xrf)

--- a/docs/developer/typescript/01_gettingStarted/02_hello/01_ecs.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/01_ecs.md
@@ -82,6 +82,6 @@ Entities without it would not have any [3D geometry](https://en.wikipedia.org/wi
 ```ts
 ECS.setComponent(entity, PrimitiveGeometryComponent, { geometryType: 1 })
 ```
-> The `1` here means that we are creating a [`SphereGeometry`](https://github.com/EtherealEngine/etherealengine/blob/dev/packages/engine/src/scene/constants/GeometryTypeEnum.ts#L28) object.  
+> The `1` here means that we are creating a [`SphereGeometry`](https://github.com/ir-engine/ir-engine/blob/dev/packages/engine/src/scene/constants/GeometryTypeEnum.ts#L28) object.  
 > We will create the component using a more readable name in the next section of the tutorial.
 

--- a/docs/developer/typescript/01_gettingStarted/02_hello/02_engine.md
+++ b/docs/developer/typescript/01_gettingStarted/02_hello/02_engine.md
@@ -35,7 +35,7 @@ They are equivalent to the concept of "projects" in other engines, except they a
 The engine scans for projects mounted in the `/packages/projects/projects` sub-folder.  
 This means that we can install and run new projects by executing the following commands inside our iR Engine installation folder:
 ```bash
-git clone https://github.com/EtherealEngine/ee-tutorial-hello packages/projects/projects/ee-tutorial-hello
+git clone https://github.com/ir-engine/ee-tutorial-hello packages/projects/projects/ee-tutorial-hello
 npm run dev
 ```
 :::note
@@ -47,7 +47,7 @@ Please note that, in the [Quickstart](../quickstart) guide, we cloned the `Step0
 We did this by adding `-b Step0` to the `git clone` command:
 
 ```bash
-git clone -b Step0 https://github.com/EtherealEngine/ee-tutorial-hello packages/projects/projects/ee-tutorial-hello
+git clone -b Step0 https://github.com/ir-engine/ee-tutorial-hello packages/projects/projects/ee-tutorial-hello
 ```
 
 This step won't be needed for your own projects.

--- a/docs/developer/typescript/01_gettingStarted/index.md
+++ b/docs/developer/typescript/01_gettingStarted/index.md
@@ -7,7 +7,7 @@ This QuickStart guide will teach you the basics of iR Engine, and how to run the
 ## Installation
 <!-- Start of partial: UbuntuInstall -->
 :::important
-Ethereal Engine is a web application.  
+iR Engine is a web application.  
 We are going to install and run a local version of the engine.  
 But this setup might not reflect how you will use the engine on a day to day basis.  
 :::
@@ -17,21 +17,21 @@ These installation instructions assume you are using Ubuntu Linux.
 You can find alternative _(and more advanced)_ installation instructions for [Windows](/manual/install/windowsWSL), [Mac](/manual/install/macOSX) and [Linux](/manual/install/linux) in the Manual.
 :::
 
-If you are on Ubuntu Linux, there is an automatic installation script to setup and run a local version of Ethereal Engine.  
+If you are on Ubuntu Linux, there is an automatic installation script to setup and run a local version of iR Engine.  
 Open a terminal window and run these two lines:  
 > Make sure that you open the terminal in the folder where you want to install the engine
 ```bash
 wget https://raw.githubusercontent.com/EtherealEngine/etherealengine/dev/scripts/ubuntu-install.sh && bash -i ./ubuntu-install.sh
 npm run reinit && npm run dev
 ```
-You can now open Ethereal Engine on your web browser by navigating to https://localhost:3000
+You can now open iR Engine on your web browser by navigating to https://localhost:3000
 
 <!-- End of partial: UbuntuInstall -->
 
 ## Projects
 ### Default Projects
 <!-- Start of partial: DefaultProjects -->
-Ethereal Engine has a few scenes that are installed by default.  
+iR Engine has a few scenes that are installed by default.  
 With the engine running, open the Studio by navigating to https://localhost:3000/studio, and you will see the engine's default project listed in that page.  
 
 Lets give it a test run:

--- a/docs/developer/typescript/01_gettingStarted/index.md
+++ b/docs/developer/typescript/01_gettingStarted/index.md
@@ -21,7 +21,7 @@ If you are on Ubuntu Linux, there is an automatic installation script to setup a
 Open a terminal window and run these two lines:  
 > Make sure that you open the terminal in the folder where you want to install the engine
 ```bash
-wget https://raw.githubusercontent.com/EtherealEngine/etherealengine/dev/scripts/ubuntu-install.sh && bash -i ./ubuntu-install.sh
+wget https://raw.githubusercontent.com/ir-engine/ir-engine/dev/scripts/ubuntu-install.sh && bash -i ./ubuntu-install.sh
 npm run reinit && npm run dev
 ```
 You can now open iR Engine on your web browser by navigating to https://localhost:3000
@@ -53,7 +53,7 @@ A local version of the engine is required to follow this introductory tutorial.
 The previous commands will have the engine running locally.  
 Lets stop it by pressing `Ctrl+C`, and then run these commands to install and run the tutorial's template project:
 ```bash
-git clone -b Step0 https://github.com/EtherealEngine/ee-tutorial-hello packages/projects/projects/ee-tutorial-hello
+git clone -b Step0 https://github.com/ir-engine/ee-tutorial-hello packages/projects/projects/ee-tutorial-hello
 npm run dev
 ```
 

--- a/docs/developer/typescript/02_basics/01_recap/02_component.md
+++ b/docs/developer/typescript/02_basics/01_recap/02_component.md
@@ -55,7 +55,7 @@ We will explore them further in later sections of the tutorial.
 The data used to create a Component with `defineComponent` is declared by the `ComponentPartial` interface.
 This type exists so that some of the properties of Components are optional when defining them, but required during normal use.  
 
-This is the shape of the `ComponentPartial` interface, defined in the [`ComponentFunctions.ts`](https://github.com/EtherealEngine/etherealengine/blob/dev/packages/ecs/src/ComponentFunctions.ts) file:
+This is the shape of the `ComponentPartial` interface, defined in the [`ComponentFunctions.ts`](https://github.com/ir-engine/ir-engine/blob/dev/packages/ecs/src/ComponentFunctions.ts) file:
 ```ts
 {
   name: string

--- a/docs/developer/typescript/98_contributing/index.md
+++ b/docs/developer/typescript/98_contributing/index.md
@@ -43,8 +43,8 @@ Talk about the engine with people you know. Let them know about those cool proje
 
 ## Contribute to iR Engine's development
 <!-- Start of partial: Develop -->
-iR Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
-You can find the source code of the engine on iR Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
+iR Engine is an open-source project, based on the [CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) license.
+You can find the source code of the engine on iR Engine's [GitHub](https://github.com/ir-engine/ir-engine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/ir-engine/etherealengine#contributing) section of the repository's readme.
 
 <!-- End of partial: Develop -->
 
@@ -53,7 +53,7 @@ You can find the source code of the engine on iR Engine's [GitHub](https://githu
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
 Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
-Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
+Search for the issue in our [Issues List](https://github.com/ir-engine/ir-engine/issues), and open a new one if you think that what you found has not been reported yet.
 
 <!-- End of partial: Test -->
 
@@ -61,9 +61,9 @@ Search for the issue in our [Issues List](https://github.com/EtherealEngine/ethe
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/ir-engine/ir-engine).  
 
-For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
+For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/ir-engine/developer-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 
 Get started by reading the [Get Involved: Documentation Guidelines](/manual/contributing/documentation).
 

--- a/docs/developer/typescript/98_contributing/index.md
+++ b/docs/developer/typescript/98_contributing/index.md
@@ -18,7 +18,7 @@ TODO
 
 ## Participate in the community
 <!-- Start of partial: Participate -->
-The easiest way to get involved is to participate in Ethereal Engine's community.  
+The easiest way to get involved is to participate in iR Engine's community.  
 Join us on your favorite [community channel](/manual/community) and become a part of the conversation.  
 Ask any questions that you may have and/or help other users with their questions.
 
@@ -26,32 +26,32 @@ Ask any questions that you may have and/or help other users with their questions
 
 ## Create and Host your own worlds
 <!-- Start of partial: Host -->
-Ethereal Engine is a platform aimed at helping you achieve your goals.
+iR Engine is a platform aimed at helping you achieve your goals.
 And nothing showcases a great tool better than some great projects made with it!
 
-Complete the **Getting Started** tutorials, learn to use the engine with the [Ethereal Engine Manual](/manual), create a cool project that you love and then share it with the world.
-<!-- TODO: Revise the copywriting of this paragraph after the `Promote Ethereal Engine` copy has been revised, so that it segues better into the next section. -->
+Complete the **Getting Started** tutorials, learn to use the engine with the [iR Engine Manual](/manual), create a cool project that you love and then share it with the world.
+<!-- TODO: Revise the copywriting of this paragraph after the `Promote iR Engine` copy has been revised, so that it segues better into the next section. -->
 
 <!-- End of partial: Host -->
 
 ## Promote iR Engine
 <!-- Start of partial: Promote -->
-Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of Ethereal Engine is a great way to help growing the community.  
+Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of iR Engine is a great way to help growing the community.  
 <!-- TODO: Improve the copywriting quality of this paragraph with better marketing information, based on Ethereal's marketing strategy. -->
 
 <!-- End of partial: Promote -->
 
 ## Contribute to iR Engine's development
 <!-- Start of partial: Develop -->
-Ethereal Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
-You can find the source code of the engine on Ethereal Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
+iR Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
+You can find the source code of the engine on iR Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
 
 <!-- End of partial: Develop -->
 
 ## Testing and reporting issues
 <!-- Start of partial: Test -->
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
-Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of Ethereal Engine.
+Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
 Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
 
@@ -61,7 +61,7 @@ Search for the issue in our [Issues List](https://github.com/EtherealEngine/ethe
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main Ethereal Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
 
 For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 

--- a/docs/developer/typescript/99_community/index.md
+++ b/docs/developer/typescript/99_community/index.md
@@ -30,7 +30,7 @@ TODO
 - [Discord](https://discord.gg/xrf)
 -->
 
-You can join Ethereal Engine's community on:
+You can join iR Engine's community on:
 - [Twitter](https://twitter.com/xr_engine)
 - [Facebook](https://www.facebook.com/xrengine/)
 - [Discord](https://discord.gg/xrf)

--- a/docs/manual/01_install/d_04_controlCenter.md
+++ b/docs/manual/01_install/d_04_controlCenter.md
@@ -20,11 +20,11 @@ The iR Engine Control Center app provides access to various functionalities whic
 - See realtime logs of different actions being performed.
 
 ## 1. Downloading Control Center App
-In order to download iR Engine Control Center App, navigate to [releases](https://github.com/EtherealEngine/etherealengine-control-center/releases) page and download the latest version of the App.
+In order to download iR Engine Control Center App, navigate to [releases](https://github.com/ir-engine/etherealengine-control-center/releases) page and download the latest version of the App.
 - **Windows** _(and WSL)_: Download the `.exe` file
 
   > You will need to allow permission for executing ps1 scripts.  
-  > You can do so by running following command in Powershell with admin privileges ([reference](https://github.com/EtherealEngine/etherealengine-control-center#2-windows-permission-to-run-ps1-scripts)).  
+  > You can do so by running following command in Powershell with admin privileges ([reference](https://github.com/ir-engine/etherealengine-control-center#2-windows-permission-to-run-ps1-scripts)).  
   > ```Powershell
   > Set-ExecutionPolicy -ExecutionPolicy Unrestricted
   >```
@@ -35,7 +35,7 @@ In order to download iR Engine Control Center App, navigate to [releases](https:
   > Afterwards, double click on AppImage to launch the app.
 
   > Ubuntu 22.04 or later:  
-  > If you are unable to launch the AppImage, you might have to install Fuse with the following command _([reference](https://github.com/EtherealEngine/etherealengine-control-center#1-app-not-launching-in-ubuntu-2204))_.
+  > If you are unable to launch the AppImage, you might have to install Fuse with the following command _([reference](https://github.com/ir-engine/etherealengine-control-center#1-app-not-launching-in-ubuntu-2204))_.
   > ```bash
   > sudo apt-get install fuse libfuse2
   >```
@@ -98,14 +98,14 @@ In this step you will need to provide the following information:
 
 - **Engine Path:**  
   This is the location of iR Engine source code repo.  
-  If the path does not contain the source code, then it will be [cloned](https://github.com/EtherealEngine/etherealengine) by the Control Center App.
+  If the path does not contain the source code, then it will be [cloned](https://github.com/ir-engine/ir-engine) by the Control Center App.
   :::info[windows]
   The path must be inside your WSL Ubuntu distribution.
   :::
 
 - **Ops Path:**  
   This is the location of iR Engine ops source code repo.  
-  If the path does not contain the source code, then it will be [cloned](https://github.com/EtherealEngine/ethereal-engine-ops) by Control Center App.
+  If the path does not contain the source code, then it will be [cloned](https://github.com/ir-engine/ir-engine-ops/) by Control Center App.
   :::info[windows]
   The path must be inside your WSL Ubuntu distribution.
   :::

--- a/docs/manual/02_scene/01_studio/01_overview/d__studio_overview.md
+++ b/docs/manual/02_scene/01_studio/01_overview/d__studio_overview.md
@@ -1,1 +1,1 @@
-![image6](https://github.com/EtherealEngine/etherealengine-docs/assets/5104160/a26ad154-64f4-4681-a011-70af9f4213e1)
+![image6](https://github.com/ir-engine/developer-docs/assets/5104160/a26ad154-64f4-4681-a011-70af9f4213e1)

--- a/docs/manual/03_modules/01_engine/d_03_stateManagement.md
+++ b/docs/manual/03_modules/01_engine/d_03_stateManagement.md
@@ -2,5 +2,5 @@
 <!--
 TODO:
 Explain how Hyperflux, etc works internally
-Task: https://github.com/EtherealEngine/etherealengine-docs/issues/72
+Task: https://github.com/ir-engine/developer-docs/issues/72
 -->

--- a/docs/manual/03_modules/05_infrastructure/02_adminPanel/01_dashboard.md
+++ b/docs/manual/03_modules/05_infrastructure/02_adminPanel/01_dashboard.md
@@ -6,7 +6,7 @@ It gives a progress report for how a deployment is performing over a certain per
 
 ## Usage Dashboard
 The usage section shows a snapshot about the current usage of a deployment.
-<img width="1280" alt="image" src="https://github.com/EtherealEngine/etherealengine-docs/assets/92340542/f0282bf5-36ec-4220-85fa-636ba156689e" />
+<img width="1280" alt="image" src="https://github.com/ir-engine/developer-docs/assets/92340542/f0282bf5-36ec-4220-85fa-636ba156689e" />
 
 It shows the status of:
 - Active Parties
@@ -18,7 +18,7 @@ It shows the status of:
 
 ## Usage Time Series
 This section shows a time series of the information in the snapshot over a customizable period of time  
-<img width="1207" alt="image" src="https://github.com/EtherealEngine/etherealengine-docs/assets/92340542/f623fa0f-72a0-49c8-82e1-51f8ddc7485b" />
+<img width="1207" alt="image" src="https://github.com/ir-engine/developer-docs/assets/92340542/f623fa0f-72a0-49c8-82e1-51f8ddc7485b" />
 
 The information is split between activity and user data.  
 The time period is set to the last 30 days by default, but it can be changed to start and end at any arbitrary date.  

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_linux.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_linux.md
@@ -193,7 +193,7 @@ helm install local-redis redis/redis
 ```
 > Important:  
 > Make sure to change `/path/to/agones-default-values.yaml` with the actual path of the file.  
-> The [agones-default-values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/agones-default-values.yaml) file can be found in the [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repository.
+> The [agones-default-values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/agones-default-values.yaml) file can be found in the [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repository.
 
 After a minute or so, all of these pods should be in the `Running` state.
 You can run this command to list all of the pods running in MicroK8s.
@@ -248,7 +248,7 @@ Edit the file `local.microk8s.template.values.yaml` and update the env variable 
 ```bash
 http://<username>:<password>@<host>:<port>
 ```
-> The file [local.microk8s.template.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) can be found in the [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> The file [local.microk8s.template.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) can be found in the [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 ## Build MicroK8s
 Run the following command from the root of the iR Engine repository after MicroK8s is running:
@@ -280,7 +280,7 @@ You can verify that the images are pushed correctly by visiting http://localhost
 
 ## Update Helm Values File
 This will use a Helm config file titled `local.values.yaml` to configure the deployment.  
-There is a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) for this file in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+There is a [template](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) for this file in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 If you are using a local file server, as explained in one of the previous steps, you will need to update the variable `api.fileServer.hostUploadFolder` in the `local.values.yaml` file with a value similar to `ENGINE_FULL_PATH/packages/server/upload`.  
 _e.g. `/home/username/etherealengine/packages/server/upload`._  
@@ -293,7 +293,7 @@ helm install -f </path/to/local.values.yaml> -f </path/to/db-refresh-true.values
 ```
 > Important:  
 > Make sure to change `/path/to/local.values.yaml` and `/path/to/db-refresh-true.values.yaml` with the actual path of the files.  
-> The file [db-refresh-true.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in the [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repository.
+> The file [db-refresh-true.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in the [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repository.
 
 After a minute or so, running `kubectl get pods` should show one or more instanceservers, one or more api servers, and one client server in the Running state.
 
@@ -304,7 +304,7 @@ helm upgrade --reuse-values -f </path/to/db-refresh-false.values.yaml> local eth
 ```
 > Important:  
 > Make sure to change `/path/to/db-refresh-true.values.yaml` with the actual path of the file.  
-> The file [db-refresh-false.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in the [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repository.
+> The file [db-refresh-false.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in the [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repository.
 
 
 ## Accept invalid certs

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_windows.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/01_microk8s_windows.md
@@ -278,7 +278,7 @@ Make sure that kubectl is pointed at MicroK8s by running `kubectl config current
 
 Once kubectl is pointed to microk8s, from the top of the iR Engine repo, run `helm install -f </path/to/agones-default-values.yaml> agones agones/agones` to install Agones and `helm install local-redis redis/redis` to install redis.
 
-> [agones-default-values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/agones-default-values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [agones-default-values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/agones-default-values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 You can run `kubectl get pods -A` to list all of the pods running in microk8s. After a minute or so, all of these pods should be in the Running state.
 
@@ -308,7 +308,7 @@ After you set up port-forwarding, access Elasticsearch, and the Kibana GUI by ty
 
 In order to connect logger with elasticsearch, update `local.microk8s.template.values.yaml` env `api.extraEnv.ELASTIC_HOST` for e.g. `http://<username>:<password>@<host>:<port>`
 
-> [local.microk8s.template.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [local.microk8s.template.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 ## Run build_microk8s.sh
 
@@ -336,7 +336,7 @@ Once the images are build. It will push it to MicroK8s local registry. You can v
 ## Update Helm Values File
 
 This will use a Helm config file titled 'local.values.yaml' to configure the deployment. There is
-a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) for this file in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+a [template](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.microk8s.template.values.yaml) for this file in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 If you are using local file server as explained couple of steps earlier then, update 'local.values.yaml' variable `api.fileServer.hostUploadFolder` with value similar to '\<ENGINE_FULL_PATH\>/packages/server/upload' e.g. '/home/\<OS_USER_NAME\>/\<ENGINE_FOLDER\>/packages/server/upload'. Its mandatory to point to `/packages/server/upload` folder of your engine folder.
 
@@ -354,11 +354,11 @@ Run the following command:
 helm install -f </path/to/local.values.yaml> -f </path/to/db-refresh-true.values.yaml> local etherealengine/etherealengine
 ```
 
-> [db-refresh-true.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [db-refresh-true.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 After a minute or so, running `kubectl get pods` should show one or more instanceservers, one or more api servers, and one client server in the Running state. Setting `FORCE_DB_REFRESH=true` made the api servers (re)initialize the database. Since you don't want that to happen every time a new api pod starts, run `helm upgrade --reuse-values -f </path/to/db-refresh-false.values.yaml> local etherealengine/etherealengine`. The API pods will restart and will now not attempt to reinit the database on boot.
 
-> [db-refresh-false.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [db-refresh-false.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 ## Accept invalid certs
 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_dockerDesktop.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_dockerDesktop.md
@@ -77,7 +77,7 @@ Once kubectl is pointed to docker-desktop, from the top of the iR Engine repo, r
 `helm install -f </path/to/agones-default-values.yaml> agones agones/agones` to install Agones
 and `helm install local-redis redis/redis` to install redis.
 
-> [agones-default-values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/agones-default-values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [agones-default-values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/agones-default-values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 You can run `kubectl get pods -A` to list all of the pods running in docker-desktop. After a minute or so,
 all of these pods should be in the Running state.
@@ -114,14 +114,14 @@ though later builds should take less time as things are cached.
 ## Update Helm Values File
 
 This will use a Helm config file titled 'local.values.yaml' to configure the deployment. There is
-a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.dockerdesktop.template.values.yaml) for this file in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+a [template](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.dockerdesktop.template.values.yaml) for this file in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 If you are using local file server as explained a couple of steps earlier then, update 'local.values.yaml' variable `api.fileServer.hostUploadFolder` with value e.g. '/hosthome/\<OS_USER_NAME\>/\<ENGINE_FOLDER\>/packages/server/upload'. The folder must be in home folder and make sure to use /hosthome/ instead of home in path. It's mandatory to point to `/packages/server/upload` folder of your engine folder.
 
 ## Deploy iR Engine Helm chart
 Run the following command: `helm install -f </path/to/local.values.yaml> -f </path/to/db-refresh-true.values.yaml> local etherealengine/etherealengine`.
 
-> [db-refresh-true.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [db-refresh-true.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 After a minute or so, running `kubectl get pods` should show one or more instanceservers, one or more api
 servers, and one client server in the Running state. Setting `FORCE_DB_REFRESH=true` made the api servers
@@ -129,7 +129,7 @@ servers, and one client server in the Running state. Setting `FORCE_DB_REFRESH=t
 `helm upgrade --reuse-values -f </path/to/db-refresh-false.values.yaml> local etherealengine/etherealengine`.
 The API pods will restart and will now not attempt to reinit the database on boot.
 
-> [db-refresh-false.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [db-refresh-false.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 ## Accept invalid certs
 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_minikube.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/02_minikube.md
@@ -95,7 +95,7 @@ Once kubectl is pointed to minikube, from the top of the iR Engine repo, run
 `helm install -f </path/to/agones-default-values.yaml> agones agones/agones` to install Agones
 and `helm install local-redis redis/redis` to install redis.
 
-> [agones-default-values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/agones-default-values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [agones-default-values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/agones-default-values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 You can run `kubectl get pods -A` to list all of the pods running in minikube. After a minute or so,
 all of these pods should be in the Running state.
@@ -128,7 +128,7 @@ After you set up port-forwarding, access Elasticsearch, and the Kibana GUI by ty
 
 In order to connect logger with elasticsearch, update `local.minikube.template.values.yaml` env `api.extraEnv.ELASTIC_HOST` for e.g. `http://<username>:<password>@<host>:<port>`
 
-> [local.minikube.template.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.minikube.template.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [local.minikube.template.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.minikube.template.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 ## Run build_minikube.sh
 When minikube is running, run the following command from the root of the iR Engine repo:
@@ -167,14 +167,14 @@ though later builds should take less time as things are cached.
 ## Update Helm Values File
 
 This will use a Helm config file titled 'local.values.yaml' to configure the deployment. There is
-a [template](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.minikube.template.values.yaml) for this file in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+a [template](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.minikube.template.values.yaml) for this file in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 If you are using local file server as explained couple of steps earlier then, update 'local.values.yaml' variable `api.fileServer.hostUploadFolder` with value e.g. '/hosthome/\<OS_USER_NAME\>/\<ENGINE_FOLDER\>/packages/server/upload'. The folder must be in home folder and make sure to use /hosthome/ instead of home in path. Its mandatory to point to `/packages/server/upload` folder of your engine folder.
 
 ## Deploy iR Engine Helm chart
 Run the following command: `helm install -f </path/to/local.values.yaml> -f </path/to/db-refresh-true.values.yaml> local etherealengine/etherealengine`.
 
-> [db-refresh-true.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [db-refresh-true.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-true.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 After a minute or so, running `kubectl get pods` should show one or more instanceservers, one or more api
 servers, and one client server in the Running state. Setting `FORCE_DB_REFRESH=true` made the api servers
@@ -182,7 +182,7 @@ servers, and one client server in the Running state. Setting `FORCE_DB_REFRESH=t
 `helm upgrade --reuse-values -f </path/to/db-refresh-false.values.yaml> local etherealengine/etherealengine`.
 The API pods will restart and will now not attempt to reinit the database on boot.
 
-> [db-refresh-false.values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [db-refresh-false.values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/db-refresh-false.values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 ## Accept invalid certs
 

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/02_EKS.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/02_EKS.md
@@ -82,7 +82,7 @@ Redis should get its own nodegroup to isolate it from any other changes that mig
 As with the instanceserver nodegroup, it's not strictly necessary, but can prevent various other things from
 going down due to the redis servers getting interrupted.
 
-Back at the Compute tab, click on Add Node Group. Pick a name (the default config in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/local.minikube.template.values.yaml) assumes
+Back at the Compute tab, click on Add Node Group. Pick a name (the default config in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/local.minikube.template.values.yaml) assumes
 a name of 'ng-redis-1'), select the IAM role that was created with the cluster 
 (it should be something like ```eksctl-<cluster_name>-node-NodeInstanceRole-<jumble_of_characters>```),
 toggle the Use Launch Template toggle and select the launch template used to make the initial nodegroup,

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/04_IAM.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/04_IAM.md
@@ -44,7 +44,7 @@ user has all of the required policies/permissions, up to and including the Admin
 for other users to have access to the cluster, the aws-auth ConfigMap in the cluster needs to be
 modified to explicitly grant them permission to access the cluster.
 
-There is an [`aws-auth.yaml`](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/aws-auth-template.yml) file template in the configs folder of the [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops/) repository.  
+There is an [`aws-auth.yaml`](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/aws-auth-template.yml) file template in the configs folder of the [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repository.  
 Make a copy of this template, shorten its name to `aws-auth.yml`, and run this command to get the current copy of the aws-auth ConfigMap:
 ```bash
 kubectl describe configmap aws-auth -n kube-system

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/08_agonesNginxRedis.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/08_agonesNginxRedis.md
@@ -16,7 +16,7 @@ If you ever suspect that a chart is out-of-date, run ```helm repo update``` to u
 ### Install Agones
 From the top level of this repo, run ```helm install -f </path/to/agones-default-values.yaml> agones agones/agones```.
 This says to install a service called 'agones' from the 'agones' package in the 'agones' chart, and to configure it with
-[agones-default-values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/agones-default-values.yaml) that can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+[agones-default-values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/agones-default-values.yaml) that can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 ### Install redis for each deployment
 
@@ -28,7 +28,7 @@ iR Engine deployment named 'dev', the corresponding redis deployment would need 
 Run ```helm install -f </path/to/redis-values.yaml> <RELEASE_NAME>-redis redis/redis``` to install, e.g.
 ```helm install -f </path/to/redis-values.yaml> dev-redis redis/redis```.
 
-> [redis-values.yaml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/redis-values.yaml) can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+> [redis-values.yaml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/redis-values.yaml) can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 If you named the redis nodegroup something other than 'ng-redis-1', you'll have to alter the value in
 `redis-values.yaml` in two places to your redis nodegroup name.
@@ -48,7 +48,7 @@ will immediately go down.
 
 ### Install ingress-nginx
 **This step cannot finish until the associated ACM Certificate is fully validated** 
-Open local version of [nginx-ingress-aws-values.yml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/nginx-ingress-aws-values.yml) file. Take note of the line
+Open local version of [nginx-ingress-aws-values.yml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/nginx-ingress-aws-values.yml) file. Take note of the line
 ```service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "<ACM Certificate ARN for SSL>"```
 Replace the bit in angle brackets, including the angle brackets, with the ARN of the certificate
 you made for the top-level domain and all wildcarded subdomains, e.g.
@@ -59,4 +59,4 @@ to the state it was committed in.
 
 From the top level of this repo, run ```helm install -f </path/to/nginx-ingress-aws-values.yml> nginx ingress-nginx/ingress-nginx```
 This says to install a service called 'nginx' from the 'ingress-nginx' package in the 'ingress-nginx' chart, and to configure it with
-a file found at [nginx-ingress-aws-values.yml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/nginx-ingress-aws-values.yml).
+a file found at [nginx-ingress-aws-values.yml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/nginx-ingress-aws-values.yml).

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/14_EKSUser.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/14_EKSUser.md
@@ -2,7 +2,7 @@
 ## Grant EKSUser access to cluster
 By default, only the IAM user who set up an EKS cluster may access it.
 In order to let other users access the cluster, you must apply an aws-auth configmap to the cluster
-granting access to specific IAM users. A template of [aws-auth-template.yml](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs/aws-auth-template.yml) file can be found in [ethereal-engine-ops](https://github.com/EtherealEngine/ethereal-engine-ops) repo.
+granting access to specific IAM users. A template of [aws-auth-template.yml](https://github.com/ir-engine/ir-engine-ops/blob/master/configs/aws-auth-template.yml) file can be found in [ir-engine-ops](https://github.com/ir-engine/ir-engine-ops/) repo.
 
 You'll need to provide a few values for this file. To find `<rolearn>`, in AWS go to EKS->Clusters->
 `<your cluster>`->Compute->Select a nodegroup.  In the details should be 'Node IAM Role ARN'; copy this

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/15_EKSDeploy.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/03_AWSSetup/15_EKSDeploy.md
@@ -6,7 +6,7 @@ There's a couple of steps to this, which will involve deploying things with most
 configuration values, and then letting the deployment process fill in the rest.
 
 ### Fill in Helm config file with variables
-Template Helm config files for dev and prod deployments can be found in [configs](https://github.com/EtherealEngine/ethereal-engine-ops/blob/master/configs) \<dev/prod\>.template.values.yaml.
+Template Helm config files for dev and prod deployments can be found in [configs](https://github.com/ir-engine/ir-engine-ops/blob/master/configs) \<dev/prod\>.template.values.yaml.
 Before filling them in, make a copy elsewhere, call that '\<dev/prod\>.values.yaml', and edit that copy.
 Both the builder and main deployments should use the same config file. When the builder seeds the database,
 it needs a number of values that only need to be configured for the other services, so all of the values

--- a/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/07_releaseHelmChart.md
+++ b/docs/manual/03_modules/05_infrastructure/03_devopsDeployment/07_releaseHelmChart.md
@@ -2,16 +2,16 @@
 <!-- TODO: Improve the formatting of this file -->
 These are the steps that needs to be taken in order to update an iR Engine Helm charts repo:
 > Pre-requisites:
-> - Have a checked-out copy of https://github.com/EtherealEngine/ethereal-engine-helm  
+> - Have a checked-out copy of https://github.com/ir-engine/ir-engine-helm  
 >   set to the `gh-pages` branch
-> - Have a checked-out copy of https://github.com/EtherealEngine/ethereal-engine-ops  
+> - Have a checked-out copy of https://github.com/ir-engine/ir-engine-ops/  
 >   set to the `master` branch
-1. Set working directory to local `ethereal-engine-ops` folder: `cd ethereal-engine-ops`
+1. Set working directory to local `ir-engine-ops` folder: `cd ir-engine-ops`
 2. Increase the version number in `etherealengine/Chart.yaml`
 3. Run `helm package etherealengine`
 4. Run `helm repo index --url https://helm.etherealengine.org .`
-5. Copy `etherealengine-X.Y.Z.tgz` that's generated to the root of the `ethereal-engine-helm` repo, and make sure to `git add` it.
+5. Copy `etherealengine-X.Y.Z.tgz` that's generated to the root of the `ir-engine-helm` repo, and make sure to `git add` it.
 6. Open `index.yaml`. Under entries.xrengine, there should be an entry for the new version.
-7. Copy that entry to `ethereal-engine-helm`'s `index.yaml`, making sure to put it under the right `entries` section; we've got `etherealengine-builder` and `etherealengine` in the same file, so pay attention to which one you're putting it in. Also make sure that the spacing/indentation matches the other entries.
-8. Copy the `generated` line from `index.yaml` to `ethereal-engine-helm/index.yaml`, overwriting the `generated` line that's there.
-9. Commit this, and push it to the `gh-pages` branch of `ethereal-engine-helm`. Within a couple of minutes, you should see the new version appear at https://helm.etherealengine.org/
+7. Copy that entry to `ir-engine-helm`'s `index.yaml`, making sure to put it under the right `entries` section; we've got `etherealengine-builder` and `etherealengine` in the same file, so pay attention to which one you're putting it in. Also make sure that the spacing/indentation matches the other entries.
+8. Copy the `generated` line from `index.yaml` to `ir-engine-helm/index.yaml`, overwriting the `generated` line that's there.
+9. Commit this, and push it to the `gh-pages` branch of `ir-engine-helm`. Within a couple of minutes, you should see the new version appear at https://helm.etherealengine.org/

--- a/docs/manual/97_license.md
+++ b/docs/manual/97_license.md
@@ -2,12 +2,12 @@
 
 # License
 <!-- Start of partial: License -->
-Ethereal Engine is [open-source](https://github.com/EtherealEngine/etherealengine), under the terms and conditions of the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.  
-Attribution is required if you wish to use Ethereal Engine under [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE).  
-Please see the attribution guidelines in Ethereal Engine's [LICENSE](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) file.
+iR Engine is [open-source](https://github.com/EtherealEngine/etherealengine), under the terms and conditions of the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.  
+Attribution is required if you wish to use iR Engine under [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE).  
+Please see the attribution guidelines in iR Engine's [LICENSE](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) file.
 
 Other licensing options are available, please contact us for more information.
 
-[CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) - Copyright (c) 2021-2023 Ethereal Engine, formerly known as XREngine by XR Foundation
+[CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) - Copyright (c) 2021-2023 iR Engine, formerly known as XREngine by XR Foundation
 
 <!-- End of partial: License -->

--- a/docs/manual/97_license.md
+++ b/docs/manual/97_license.md
@@ -2,12 +2,12 @@
 
 # License
 <!-- Start of partial: License -->
-iR Engine is [open-source](https://github.com/EtherealEngine/etherealengine), under the terms and conditions of the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.  
-Attribution is required if you wish to use iR Engine under [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE).  
-Please see the attribution guidelines in iR Engine's [LICENSE](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) file.
+iR Engine is [open-source](https://github.com/ir-engine/ir-engine), under the terms and conditions of the [CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) license.  
+Attribution is required if you wish to use iR Engine under [CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE).  
+Please see the attribution guidelines in iR Engine's [LICENSE](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) file.
 
 Other licensing options are available, please contact us for more information.
 
-[CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) - Copyright (c) 2021-2023 iR Engine, formerly known as XREngine by XR Foundation
+[CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) - Copyright (c) 2021-2023 iR Engine, formerly known as XREngine by XR Foundation
 
 <!-- End of partial: License -->

--- a/docs/manual/98_contributing/index.md
+++ b/docs/manual/98_contributing/index.md
@@ -29,7 +29,7 @@ TODO
 
 ## Participate in the community
 <!-- Start of partial: Participate -->
-The easiest way to get involved is to participate in Ethereal Engine's community.  
+The easiest way to get involved is to participate in iR Engine's community.  
 Join us on your favorite [community channel](/manual/community) and become a part of the conversation.  
 Ask any questions that you may have and/or help other users with their questions.
 
@@ -37,32 +37,32 @@ Ask any questions that you may have and/or help other users with their questions
 
 ## Create and Host your own worlds
 <!-- Start of partial: Host -->
-Ethereal Engine is a platform aimed at helping you achieve your goals.
+iR Engine is a platform aimed at helping you achieve your goals.
 And nothing showcases a great tool better than some great projects made with it!
 
-Complete the **Getting Started** tutorials, learn to use the engine with the [Ethereal Engine Manual](/manual), create a cool project that you love and then share it with the world.
-<!-- TODO: Revise the copywriting of this paragraph after the `Promote Ethereal Engine` copy has been revised, so that it segues better into the next section. -->
+Complete the **Getting Started** tutorials, learn to use the engine with the [iR Engine Manual](/manual), create a cool project that you love and then share it with the world.
+<!-- TODO: Revise the copywriting of this paragraph after the `Promote iR Engine` copy has been revised, so that it segues better into the next section. -->
 
 <!-- End of partial: Host -->
 
 ## Promote iR Engine
 <!-- Start of partial: Promote -->
-Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of Ethereal Engine is a great way to help growing the community.  
+Talk about the engine with people you know. Let them know about those cool projects that you have created, or those locations that you like the most. Being a user and overall advocate of iR Engine is a great way to help growing the community.  
 <!-- TODO: Improve the copywriting quality of this paragraph with better marketing information, based on Ethereal's marketing strategy. -->
 
 <!-- End of partial: Promote -->
 
 ## Contribute to iR Engine's development
 <!-- Start of partial: Develop -->
-Ethereal Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
-You can find the source code of the engine on Ethereal Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
+iR Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
+You can find the source code of the engine on iR Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
 
 <!-- End of partial: Develop -->
 
 ## Testing and reporting issues
 <!-- Start of partial: Test -->
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
-Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of Ethereal Engine.
+Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
 Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
 
@@ -72,7 +72,7 @@ Search for the issue in our [Issues List](https://github.com/EtherealEngine/ethe
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main Ethereal Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
 
 For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 

--- a/docs/manual/98_contributing/index.md
+++ b/docs/manual/98_contributing/index.md
@@ -54,8 +54,8 @@ Talk about the engine with people you know. Let them know about those cool proje
 
 ## Contribute to iR Engine's development
 <!-- Start of partial: Develop -->
-iR Engine is an open-source project, based on the [CPAL](https://github.com/EtherealEngine/etherealengine/blob/dev/LICENSE) license.
-You can find the source code of the engine on iR Engine's [GitHub](https://github.com/EtherealEngine/etherealengine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/EtherealEngine/etherealengine#contributing) section of the repository's readme.
+iR Engine is an open-source project, based on the [CPAL](https://github.com/ir-engine/ir-engine/blob/dev/LICENSE) license.
+You can find the source code of the engine on iR Engine's [GitHub](https://github.com/ir-engine/ir-engine) repository, and some guidelines on how to contribute to its codebase in the [Contributing](https://github.com/ir-engine/etherealengine#contributing) section of the repository's readme.
 
 <!-- End of partial: Develop -->
 
@@ -64,7 +64,7 @@ You can find the source code of the engine on iR Engine's [GitHub](https://githu
 Our team is constantly on the lookout for potential issues during development, and we have a really high standard for Code Reviewing and QA _(Quality Assurance)_. But sometimes bugs can go unnoticed and sneak into release versions of the codebase.
 Because of this, another great way to contribute is by reporting errors, problems or issues that may show up in different versions of iR Engine.
 
-Search for the issue in our [Issues List](https://github.com/EtherealEngine/etherealengine/issues), and open a new one if you think that what you found has not been reported yet.
+Search for the issue in our [Issues List](https://github.com/ir-engine/ir-engine/issues), and open a new one if you think that what you found has not been reported yet.
 
 <!-- End of partial: Test -->
 
@@ -72,9 +72,9 @@ Search for the issue in our [Issues List](https://github.com/EtherealEngine/ethe
 <!-- Start of partial: Documentation -->
 Documentation tasks are a great way to get started if you are new to the engine and/or development in general.  
 
-If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/EtherealEngine/etherealengine).  
+If you are comfortable with code, the engine uses `JSDoc` and `TypeDoc` for generating its [API documentation](https://etherealengine.github.io/etherealengine-docs/typedoc), which is generated form the source code of the main iR Engine's [source code repository](https://github.com/ir-engine/ir-engine).  
 
-For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/EtherealEngine/etherealengine-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
+For an easier task, the documentation website you are reading right now is maintained from its own [GitHub repository](https://github.com/ir-engine/developer-docs). Find something that you think could be improved in this website, and either open an issue or send a PR with your proposed changes.
 
 Get started by reading the [Get Involved: Documentation Guidelines](/manual/contributing/documentation).
 

--- a/docs/manual/99_community/index.md
+++ b/docs/manual/99_community/index.md
@@ -30,7 +30,7 @@ TODO
 - [Discord](https://discord.gg/xrf)
 -->
 
-You can join Ethereal Engine's community on:
+You can join iR Engine's community on:
 - [Twitter](https://twitter.com/xr_engine)
 - [Facebook](https://www.facebook.com/xrengine/)
 - [Discord](https://discord.gg/xrf)

--- a/docs/manual/d__partials/controlCenter/step_configurations.md
+++ b/docs/manual/d__partials/controlCenter/step_configurations.md
@@ -2,14 +2,14 @@ In this step you will need to provide the following information:
 
 - **Engine Path:**  
   This is the location of iR Engine source code repo.  
-  If the path does not contain the source code, then it will be [cloned](https://github.com/EtherealEngine/etherealengine) by the Control Center App.
+  If the path does not contain the source code, then it will be [cloned](https://github.com/ir-engine/ir-engine) by the Control Center App.
   :::info[windows]
   The path must be inside your WSL Ubuntu distribution.
   :::
 
 - **Ops Path:**  
   This is the location of iR Engine ops source code repo.  
-  If the path does not contain the source code, then it will be [cloned](https://github.com/EtherealEngine/ethereal-engine-ops) by Control Center App.
+  If the path does not contain the source code, then it will be [cloned](https://github.com/ir-engine/ir-engine-ops/) by Control Center App.
   :::info[windows]
   The path must be inside your WSL Ubuntu distribution.
   :::


### PR DESCRIPTION
This PR replaces all mentioning of Ethereal Engine with ir-engine. This includes naming, GitHub repositories, and hyperlinks.